### PR TITLE
Reorganize AppBar use

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports =  {
     },
     rules:  {
         '@typescript-eslint/explicit-function-return-type': 'off',
+        'react/prop-types': 'off', // Not needed because typescript can give us strong typing
     },
     reportUnusedDisableDirectives: true, // Want to make sure the disable directives are always being used
     root: true, // This is the root eslint file (not a nested eslint file)

--- a/src/components/ApplicationBar/ApplicationBar.tsx
+++ b/src/components/ApplicationBar/ApplicationBar.tsx
@@ -113,7 +113,9 @@ const ApplicationBar: FunctionComponent<ApplicationBarProps> = ({
                         ModalProps={{
                             keepMounted: true, // Better open performance on mobile.
                         }}
-                    ></Drawer>
+                    >
+                        {drawerContent}
+                    </Drawer>
                 </Hidden>
                 <Hidden xsDown implementation="css">
                     <Drawer

--- a/src/components/ApplicationBar/ApplicationBar.tsx
+++ b/src/components/ApplicationBar/ApplicationBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import AppBar from '@material-ui/core/AppBar'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import Drawer from '@material-ui/core/Drawer'
@@ -56,7 +56,14 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 )
 
-export default function ApplicationBar() {
+interface ApplicationBarProps {
+    drawerContent: React.ReactNode
+}
+
+const ApplicationBar: FunctionComponent<ApplicationBarProps> = ({
+    drawerContent,
+    children,
+}) => {
     const classes = useStyles()
     const theme = useTheme()
     const [mobileOpen, setMobileOpen] = React.useState(false)
@@ -64,12 +71,6 @@ export default function ApplicationBar() {
     const handleDrawerToggle = () => {
         setMobileOpen(!mobileOpen)
     }
-
-    const drawer = (
-        <div>
-            <h1>HELLO THIS IS DRAWER</h1>
-        </div>
-    )
 
     return (
         <div className={classes.root}>
@@ -122,15 +123,16 @@ export default function ApplicationBar() {
                         variant="permanent"
                         open
                     >
-                        {drawer}
+                        {drawerContent}
                     </Drawer>
                 </Hidden>
             </nav>
             <main className={classes.content}>
                 <div className={classes.toolbar} />
-                {/* Insert CourseContent here */}
-                <Typography paragraph>INSERT CONTENT HERE</Typography>
+                {children}
             </main>
         </div>
     )
 }
+
+export default ApplicationBar

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -17,12 +17,19 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 )
 
+const drawerContent = (
+    <div>
+        <h1>A drawer</h1>
+    </div>
+)
+
 export const App: React.FC = () => {
     const classes = useStyles()
     return (
         <div id="app" className={classes.root}>
-            <ApplicationBar />
-            <h1>Content put here will not be rendered properly </h1>
+            <ApplicationBar drawerContent={drawerContent}>
+                <h1>Content put here will be rendered properly </h1>
+            </ApplicationBar>
         </div>
     )
 }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,15 +1,8 @@
 import React from 'react'
-import NavBar from '../nav/nav'
-import {
-    makeStyles,
-    Theme,
-    createStyles,
-    Grid,
-    AppBar,
-} from '@material-ui/core'
+import { makeStyles, createStyles } from '@material-ui/core'
 import ApplicationBar from '../ApplicationBar/ApplicationBar'
 
-const useStyles = makeStyles((theme: Theme) =>
+const useStyles = makeStyles(() =>
     createStyles({
         root: {
             display: 'grid',


### PR DESCRIPTION
 - Change Application Bar to accept children and drawer component

This allows the ApplicationBar to be used at a higher level.
The application bar renders all of the appropriate app bar things but
allows the drawer content and the main content to be passed in so it
does not need to be aware of what is rendered inside.